### PR TITLE
Two ways to create ElementalClient

### DIFF
--- a/live/client.py
+++ b/live/client.py
@@ -1,21 +1,37 @@
 import requests
 from jinja2 import Template
+import time
+from urllib.parse import urlparse
+import hashlib
 
 
 class ElementalLive():
-    def __init__(self, server_ip):
+    def __init__(self, server_ip, user=None, api_key=None):
         self.server_ip = server_ip
+        self.user = user
+        self.api_key = api_key
 
-    # Simple version of generate_header,
-    # may need more paras in the future(like api_key)
-    def generate_headers(self):
+    def generate_headers_with_authentication_enabled(self, url, user, api_key):
+        expiration = int(time.time() + 120)
+        parse = urlparse(url)
+        prehash = "%s%s%s%s" % (parse.path, user, api_key, expiration)
+        digest = hashlib.md5(prehash.encode('utf-8')).hexdigest()
+        final_hash = "%s%s" % (api_key, digest)
+        key = hashlib.md5(final_hash.encode('utf-8')).hexdigest()
+        return {
+            'X-Auth-User': user,
+            'X-Auth-Expires': str(expiration),
+            'X-Auth-Key': key,
+            'Accept': 'application/xml',
+            'Content-Type': 'application/xml'
+        }
+
+    def generate_header_with_authentication_disabled(self):
         return {
             'Accept': 'application/xml',
             'Content-Type': 'application/xml'
         }
 
-    # Create event, options contain username,
-    # password and mediastore_container url
     def create_event(self, template_path, options):
 
         # Initiate url
@@ -29,9 +45,16 @@ class ElementalLive():
         # Pass params to template
         body = template.render(**options)
 
+        # Generate headers according to how users create ElementalLive class
+        if self.user is None and self.api_key is None:
+            headers = self.generate_header_with_authentication_disabled()
+        else:
+            headers = self.generate_headers_with_authentication_enabled(
+                url, self.user, self.api_key)
+
         # Send request
         response = requests.request(method='POST', url=url, data=body,
-                                    headers=self.generate_headers())
+                                    headers=headers)
 
         return response
 
@@ -40,8 +63,16 @@ class ElementalLive():
         # Initial url
         url = f'{self.server_ip}/live_events/{event_id}'
 
+        # Generate headers according to how users create ElementalLive class
+        if self.user is None and self.api_key is None:
+            headers = self.generate_header_with_authentication_disabled()
+        else:
+            headers = self.generate_headers_with_authentication_enabled(
+                url, self.user, self.api_key)
+
         # Send request
-        response = requests.request(method='DELETE', url=url)
+        response = requests.request(method='DELETE', url=url,
+                                    headers=headers)
 
         return response
 
@@ -53,9 +84,16 @@ class ElementalLive():
         # Generate body
         body = "<start></start>"
 
+        # Generate headers according to how users create ElementalLive class
+        if self.user is None and self.api_key is None:
+            headers = self.generate_header_with_authentication_disabled()
+        else:
+            headers = self.generate_headers_with_authentication_enabled(
+                url, self.user, self.api_key)
+
         # Send request
         response = requests.request(method='POST', url=url, data=body,
-                                    headers=self.generate_headers())
+                                    headers=headers)
 
         return response
 
@@ -67,8 +105,15 @@ class ElementalLive():
         # Generate body
         body = "<stop></stop>"
 
+        # Generate headers according to how users create ElementalLive class
+        if self.user is None and self.api_key is None:
+            headers = self.generate_header_with_authentication_disabled()
+        else:
+            headers = self.generate_headers_with_authentication_enabled(
+                url, self.user, self.api_key)
+
         # Send request
         response = requests.request(method='POST', url=url, data=body,
-                                    headers=self.generate_headers())
+                                    headers=headers)
 
         return response

--- a/live/client_test.py
+++ b/live/client_test.py
@@ -3,6 +3,9 @@ import mock
 import os
 import re
 
+USER = "FAKE"
+API_KEY = "FAKE"
+
 
 def mock_response(status=200, content="CONTENT",
                   json_data=None, raise_for_status=None):
@@ -29,7 +32,36 @@ def test_ElementalLive_should_receive_server_ip():
 
 
 @mock.patch('requests.request')
-def test_create_event_should_receive_201_status_code(mock_request):
+def test_create_event_with_authentication(mock_request):
+    """test create_event method"""
+    response_from_elemental_api = open(
+        'live/templates/sample_response_for_create.xml').read()
+    mock_request.return_value = mock_response(
+        status=201, content=response_from_elemental_api)
+
+    client = ElementalLive("http://elemental.dev.cbsivideo.com", USER, API_KEY)
+    response = client.create_event("live/templates/qvbr_mediastore.xml",
+                                   {'username': os.getenv('ACCESS_KEY'),
+                                    'password': os.getenv('SECRET_KEY'),
+                                    'mediastore_container_master':
+                                        'https://hu5n3jjiyi2jev.data.media'
+                                        'store.us-east-1.amazonaws.com/master',
+                                    'mediastore_container_backup':
+                                        'https://hu5n3jjiyi2jev.data.medias'
+                                        'tore.us-east-1.amazonaws.com/backup',
+                                    'channel': "1", 'device_name': "0"})
+
+    request_to_elemental = mock_request.call_args_list[0][1]
+    assert request_to_elemental['url'] == 'http://elemental' \
+                                          '.dev.cbsivideo.com/live_events'
+    assert request_to_elemental['method'] == 'POST'
+    assert request_to_elemental['headers']['Accept'] == 'application/xml'
+    assert request_to_elemental['headers']['Content-Type'] == 'application/xml'
+    assert response.status_code == 201
+
+
+@mock.patch('requests.request')
+def test_create_event_without_authentication(mock_request):
     """test create_event method"""
     response_from_elemental_api = open(
         'live/templates/sample_response_for_create.xml').read()
@@ -45,19 +77,42 @@ def test_create_event_should_receive_201_status_code(mock_request):
                                         'store.us-east-1.amazonaws.com/master',
                                     'mediastore_container_backup':
                                         'https://hu5n3jjiyi2jev.data.medias'
-                                        'tore.us-east-1.amazonaws.com/backup'})
+                                        'tore.us-east-1.amazonaws.com/backup',
+                                    'channel': "1", 'device_name': "0"})
 
     request_to_elemental = mock_request.call_args_list[0][1]
     assert request_to_elemental['url'] == 'http://elemental' \
                                           '.dev.cbsivideo.com/live_events'
     assert request_to_elemental['method'] == 'POST'
-    assert request_to_elemental['headers'] == {
-        'Accept': 'application/xml', 'Content-Type': 'application/xml'}
+    assert request_to_elemental['headers']['Accept'] == 'application/xml'
+    assert request_to_elemental['headers']['Content-Type'] == 'application/xml'
     assert response.status_code == 201
 
 
 @mock.patch('requests.request')
-def test_delete_event_should_receive_200_status_code(mock_request):
+def test_delete_event_with_authentication(mock_request):
+    """test delete_event method"""
+    response_from_elemental_api = open(
+        'live/templates/sample_response_for_delete.xml').read()
+    mock_request.return_value = mock_response(
+        status=200, content=response_from_elemental_api)
+
+    # Set match pattern
+    delete_pattern = re.compile(
+        r'http://elemental.dev.cbsivideo.com/live_events/(\d+)')
+    client = ElementalLive("http://elemental.dev.cbsivideo.com", USER, API_KEY)
+
+    # Mock delete function
+    response = client.delete_event(event_id=42)
+
+    request_to_elemental = mock_request.call_args_list[0][1]
+    assert delete_pattern.match(request_to_elemental['url'])
+    assert request_to_elemental['method'] == 'DELETE'
+    assert response.status_code == 200
+
+
+@mock.patch('requests.request')
+def test_delete_event_without_authentication(mock_request):
     """test delete_event method"""
     response_from_elemental_api = open(
         'live/templates/sample_response_for_delete.xml').read()
@@ -79,7 +134,31 @@ def test_delete_event_should_receive_200_status_code(mock_request):
 
 
 @mock.patch('requests.request')
-def test_start_event_should_receive_200_status_code(mock_request):
+def test_start_event_with_authentication(mock_request):
+    """test start_event method"""
+    response_from_elemental_api = open(
+        'live/templates/sample_response_for_start.xml').read()
+    mock_request.return_value = mock_response(
+        status=200, content=response_from_elemental_api)
+
+    # Set match pattern
+    delete_pattern = re.compile(
+        r'http://elemental.dev.cbsivideo.com/live_events/(\d+)/start')
+    client = ElementalLive("http://elemental.dev.cbsivideo.com", USER, API_KEY)
+
+    # Mock delete function
+    response = client.start_event(event_id=42)
+
+    request_to_elemental = mock_request.call_args_list[0][1]
+    assert delete_pattern.match(request_to_elemental['url'])
+    assert request_to_elemental['method'] == 'POST'
+    assert request_to_elemental['headers']['Accept'] == 'application/xml'
+    assert request_to_elemental['headers']['Content-Type'] == 'application/xml'
+    assert response.status_code == 200
+
+
+@mock.patch('requests.request')
+def test_start_event_without_authentication(mock_request):
     """test start_event method"""
     response_from_elemental_api = open(
         'live/templates/sample_response_for_start.xml').read()
@@ -97,13 +176,37 @@ def test_start_event_should_receive_200_status_code(mock_request):
     request_to_elemental = mock_request.call_args_list[0][1]
     assert delete_pattern.match(request_to_elemental['url'])
     assert request_to_elemental['method'] == 'POST'
-    assert request_to_elemental['headers'] == {
-        'Accept': 'application/xml', 'Content-Type': 'application/xml'}
+    assert request_to_elemental['headers']['Accept'] == 'application/xml'
+    assert request_to_elemental['headers']['Content-Type'] == 'application/xml'
     assert response.status_code == 200
 
 
 @mock.patch('requests.request')
-def test_stop_event_should_receive_200_status_code(mock_request):
+def test_stop_event_with_authentication(mock_request):
+    """test stop_event method"""
+    response_from_elemental_api = open(
+        'live/templates/sample_response_for_start.xml').read()
+    mock_request.return_value = mock_response(
+        status=200, content=response_from_elemental_api)
+
+    # Set match pattern
+    delete_pattern = re.compile(
+        r'http://elemental.dev.cbsivideo.com/live_events/(\d+)/stop')
+    client = ElementalLive("http://elemental.dev.cbsivideo.com", USER, API_KEY)
+
+    # Mock delete function
+    response = client.stop_event(event_id=42)
+
+    request_to_elemental = mock_request.call_args_list[0][1]
+    assert delete_pattern.match(request_to_elemental['url'])
+    assert request_to_elemental['method'] == 'POST'
+    assert request_to_elemental['headers']['Accept'] == 'application/xml'
+    assert request_to_elemental['headers']['Content-Type'] == 'application/xml'
+    assert response.status_code == 200
+
+
+@mock.patch('requests.request')
+def test_stop_event_without_authentication(mock_request):
     """test stop_event method"""
     response_from_elemental_api = open(
         'live/templates/sample_response_for_start.xml').read()
@@ -121,6 +224,6 @@ def test_stop_event_should_receive_200_status_code(mock_request):
     request_to_elemental = mock_request.call_args_list[0][1]
     assert delete_pattern.match(request_to_elemental['url'])
     assert request_to_elemental['method'] == 'POST'
-    assert request_to_elemental['headers'] == {
-        'Accept': 'application/xml', 'Content-Type': 'application/xml'}
+    assert request_to_elemental['headers']['Accept'] == 'application/xml'
+    assert request_to_elemental['headers']['Content-Type'] == 'application/xml'
     assert response.status_code == 200

--- a/live/templates/qvbr_mediastore.xml
+++ b/live/templates/qvbr_mediastore.xml
@@ -19,8 +19,8 @@
     <timecode_source>embedded</timecode_source>
     <device_input>
       <device_type>AJA</device_type>
-      <device_number>0</device_number>
-      <channel>1</channel>
+      <device_number>{{ device_number }}</device_number>
+      <channel>{{ channel }}</channel>
       <channel_type>HD-SDI</channel_type>
       <device_name>HD-SDI 1</device_name>
       <name nil="true"/>


### PR DESCRIPTION
1. Add 'device_name' and 'channel' params to template
2. Users can now use two ways to create ElementalClient, with authentication and without authentication
3. Adjust test file