### PR TITLE
Publish to PyPI when releases are created on Github

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,30 @@
+name: CI
+
+on:
+  release:
+    types: [ created ]
+
+env:
+  PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
+
+jobs:
+  test:
+    name: Publish to PyPI
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - name: Install test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install poetry==1.1.3
+      - name: Install Dependencies
+        run: poetry install
+      - name: Publish to PyPI
+        run: |
+          poetry config pypi-token.pypi ${{ PYPI_TOKEN }}
+          bash scripts/publish.sh

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,3 @@ lint:
 
 test:
 	tox
-
-release: clean-build
-	poetry publish --build

--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ To run lint, use
     make lint
 
 ## Release Updated Version
-First, make sure you have been added as a collaborator [here](https://pypi.org/manage/project/python-elemental/collaboration/).
-Manually increase the version [here](https://github.com/cbsinteractive/elemental/blob/master/pyproject.toml#L3) and run
-
-    make release
+Use the Github UI to [create a new release](https://github.com/cbsinteractive/elemental/releases/new), the tag needs
+to follow the semver format `0.0.0`. After the new release is created, a Github workflow will build and publish the
+new python package to PyPI automatically.

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -e
+set -x
+
+version=$(git describe --tags --abbrev=0)
+poetry version "${version}"
+poetry publish --build


### PR DESCRIPTION
Fixes #74 

I've added a token that can publish to PyPI to the repository already.