### PR TITLE
Add function to pause and unpause event's outputs

### DIFF
--- a/elemental/client.py
+++ b/elemental/client.py
@@ -134,6 +134,18 @@ class ElementalLive:
         headers = self.generate_headers(url)
         self.send_request(http_method="POST", url=url, headers=headers, body=body, timeout=timeout)
 
+    def event_pause_output(self, event_id: str, output_id: str, timeout: Optional[int] = None) -> None:
+        url = f'{self.server_url}/live_events/{event_id}/pause_output'
+        body = f"<output_id>{output_id}</output_id>"
+        headers = self.generate_headers(url)
+        self.send_request(http_method="POST", url=url, headers=headers, body=body, timeout=timeout)
+
+    def event_unpause_output(self, event_id: str, output_id: str, timeout: Optional[int] = None) -> None:
+        url = f'{self.server_url}/live_events/{event_id}/unpause_output'
+        body = f"<output_id>{output_id}</output_id>"
+        headers = self.generate_headers(url)
+        self.send_request(http_method="POST", url=url, headers=headers, body=body, timeout=timeout)
+
     def reset_event(self, event_id: str, timeout: Optional[int] = None) -> None:
         url = f'{self.server_url}/live_events/{event_id}/reset'
         headers = self.generate_headers(url)

--- a/elemental/client.py
+++ b/elemental/client.py
@@ -146,6 +146,18 @@ class ElementalLive:
         headers = self.generate_headers(url)
         self.send_request(http_method="POST", url=url, headers=headers, body=body, timeout=timeout)
 
+    def event_start_output(self, event_id: str, output_id: str, timeout: Optional[int] = None) -> None:
+        url = f'{self.server_url}/live_events/{event_id}/start_output'
+        body = f"<output_id>{output_id}</output_id>"
+        headers = self.generate_headers(url)
+        self.send_request(http_method="POST", url=url, headers=headers, body=body, timeout=timeout)
+
+    def event_stop_output(self, event_id: str, output_id: str, timeout: Optional[int] = None) -> None:
+        url = f'{self.server_url}/live_events/{event_id}/stop_output'
+        body = f"<output_id>{output_id}</output_id>"
+        headers = self.generate_headers(url)
+        self.send_request(http_method="POST", url=url, headers=headers, body=body, timeout=timeout)
+
     def reset_event(self, event_id: str, timeout: Optional[int] = None) -> None:
         url = f'{self.server_url}/live_events/{event_id}/reset'
         headers = self.generate_headers(url)

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -620,3 +620,53 @@ def test_event_unpause_output():
     assert send_mock_call['http_method'] == 'POST'
     assert send_mock_call['url'] == f'{ELEMENTAL_ADDRESS}/live_events/53/unpause_output'
     assert send_mock_call['headers'] == {'Accept': 'application/xml', 'Content-Type': 'application/xml'}
+
+
+def test_event_start_output():
+    client = ElementalLive(ELEMENTAL_ADDRESS, USER, API_KEY)
+    client.generate_headers = mock.Mock()
+    client.generate_headers.return_value = {'Accept': 'application/xml', 'Content-Type': 'application/xml'}
+    client.send_request = mock.Mock()
+    client.send_request.return_value = mock_response(status=200)
+
+    client.event_start_output(event_id='53', output_id='13')
+
+    client.send_request.assert_called_once_with(
+        http_method='POST',
+        url='FAKE_ADDRESS.com/live_events/53/start_output',
+        headers={
+            'Accept': 'application/xml',
+            'Content-Type': 'application/xml'
+        },
+        body='<output_id>13</output_id>',
+        timeout=None
+    )
+    send_mock_call = client.send_request.call_args_list[0][1]
+    assert send_mock_call['http_method'] == 'POST'
+    assert send_mock_call['url'] == f'{ELEMENTAL_ADDRESS}/live_events/53/start_output'
+    assert send_mock_call['headers'] == {'Accept': 'application/xml', 'Content-Type': 'application/xml'}
+
+
+def test_event_stop_output():
+    client = ElementalLive(ELEMENTAL_ADDRESS, USER, API_KEY)
+    client.generate_headers = mock.Mock()
+    client.generate_headers.return_value = {'Accept': 'application/xml', 'Content-Type': 'application/xml'}
+    client.send_request = mock.Mock()
+    client.send_request.return_value = mock_response(status=200)
+
+    client.event_stop_output(event_id='53', output_id='13')
+
+    client.send_request.assert_called_once_with(
+        http_method='POST',
+        url='FAKE_ADDRESS.com/live_events/53/stop_output',
+        headers={
+            'Accept': 'application/xml',
+            'Content-Type': 'application/xml'
+        },
+        body='<output_id>13</output_id>',
+        timeout=None
+    )
+    send_mock_call = client.send_request.call_args_list[0][1]
+    assert send_mock_call['http_method'] == 'POST'
+    assert send_mock_call['url'] == f'{ELEMENTAL_ADDRESS}/live_events/53/stop_output'
+    assert send_mock_call['headers'] == {'Accept': 'application/xml', 'Content-Type': 'application/xml'}

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -67,7 +67,8 @@ def test_send_request_should_call_request_as_expected():
     client.session.request = mock.MagicMock(
         return_value=mock_response(status=200))
     client.send_request(
-        'POST', f'{ELEMENTAL_ADDRESS}/live_events', HEADERS, REQUEST_BODY, timeout=TIMEOUT)
+        'POST', f'{ELEMENTAL_ADDRESS}/live_events', {'Accept': 'application/xml', 'Content-Type': 'application/xml'},
+        REQUEST_BODY, timeout=TIMEOUT)
 
     request_to_elemental = client.session.request.call_args_list[0][1]
     assert request_to_elemental['url'] == f'{ELEMENTAL_ADDRESS}/live_events'
@@ -83,7 +84,8 @@ def test_send_request_should_return_response_on_correct_status_code():
     client.session.request = mock.MagicMock(return_value=mock_response(
         status=201, text=response_from_elemental_api))
     response = client.send_request(
-        'POST', f'{ELEMENTAL_ADDRESS}/live_events', HEADERS, REQUEST_BODY)
+        'POST', f'{ELEMENTAL_ADDRESS}/live_events', {'Accept': 'application/xml', 'Content-Type': 'application/xml'},
+        REQUEST_BODY)
 
     assert response.text == response_from_elemental_api
     assert response.status_code == 201
@@ -96,7 +98,8 @@ def test_send_request_should_raise_InvalidRequest_on_RequestException():
 
     with pytest.raises(InvalidRequest):
         client.send_request(
-            'POST', f'{ELEMENTAL_ADDRESS}/live_events', HEADERS, REQUEST_BODY)
+            'POST', f'{ELEMENTAL_ADDRESS}/live_events',
+            {'Accept': 'application/xml', 'Content-Type': 'application/xml'}, REQUEST_BODY)
 
 
 def test_send_request_should_raise_InvalidResponse_on_invalid_status_code():
@@ -108,7 +111,8 @@ def test_send_request_should_raise_InvalidResponse_on_invalid_status_code():
 
     with pytest.raises(InvalidResponse) as exc_info:
         client.send_request(
-            'POST', f'{ELEMENTAL_ADDRESS}/live_events', HEADERS, REQUEST_BODY)
+            'POST', f'{ELEMENTAL_ADDRESS}/live_events',
+            {'Accept': 'application/xml', 'Content-Type': 'application/xml'}, REQUEST_BODY)
 
     assert str(exc_info.value).endswith(
         f"Response: 404\n{response_from_elemental_api}")
@@ -118,7 +122,7 @@ def test_create_event():
     client = ElementalLive(ELEMENTAL_ADDRESS, USER, API_KEY)
 
     client.generate_headers = mock.Mock()
-    client.generate_headers.return_value = HEADERS
+    client.generate_headers.return_value = {'Accept': 'application/xml', 'Content-Type': 'application/xml'}
 
     client.send_request = mock.Mock()
     elemental_response = file_fixture('success_response_for_create.xml')
@@ -137,14 +141,14 @@ def test_create_event():
     send_mock_call = client.send_request.call_args_list[0][1]
     assert send_mock_call['http_method'] == 'POST'
     assert send_mock_call['url'] == f'{ELEMENTAL_ADDRESS}/live_events'
-    assert send_mock_call['headers'] == HEADERS
+    assert send_mock_call['headers'] == {'Accept': 'application/xml', 'Content-Type': 'application/xml'}
     assert event_id == {'id': '53'}
 
 
 def test_update_event():
     client = ElementalLive(ELEMENTAL_ADDRESS, USER, API_KEY)
     client.generate_headers = mock.Mock()
-    client.generate_headers.return_value = HEADERS
+    client.generate_headers.return_value = {'Accept': 'application/xml', 'Content-Type': 'application/xml'}
     client.send_request = mock.Mock()
     client.send_request.return_value = mock_response(
         status=200)
@@ -159,13 +163,13 @@ def test_update_event():
     send_mock_call = client.send_request.call_args_list[0][1]
     assert send_mock_call['http_method'] == 'PUT'
     assert send_mock_call['url'] == f'{ELEMENTAL_ADDRESS}/live_events/53'
-    assert send_mock_call['headers'] == HEADERS
+    assert send_mock_call['headers'] == {'Accept': 'application/xml', 'Content-Type': 'application/xml'}
 
 
 def test_update_event_with_restart():
     client = ElementalLive(ELEMENTAL_ADDRESS, USER, API_KEY)
     client.generate_headers = mock.Mock()
-    client.generate_headers.return_value = HEADERS
+    client.generate_headers.return_value = {'Accept': 'application/xml', 'Content-Type': 'application/xml'}
     client.send_request = mock.Mock()
     client.send_request.return_value = mock_response(
         status=200)
@@ -180,14 +184,14 @@ def test_update_event_with_restart():
     send_mock_call = client.send_request.call_args_list[0][1]
     assert send_mock_call['http_method'] == 'PUT'
     assert send_mock_call['url'] == f'{ELEMENTAL_ADDRESS}/live_events/53?unlocked=1'
-    assert send_mock_call['headers'] == HEADERS
+    assert send_mock_call['headers'] == {'Accept': 'application/xml', 'Content-Type': 'application/xml'}
 
 
 def test_delete_event_should_call_send_request_as_expect():
     client = ElementalLive(ELEMENTAL_ADDRESS, USER, API_KEY)
 
     client.generate_headers = mock.Mock()
-    client.generate_headers.return_value = HEADERS
+    client.generate_headers.return_value = {'Accept': 'application/xml', 'Content-Type': 'application/xml'}
 
     client.send_request = mock.Mock()
     client.send_request.return_value = mock_response(status=200)
@@ -196,14 +200,15 @@ def test_delete_event_should_call_send_request_as_expect():
     client.delete_event(event_id)
     client.send_request.assert_called_once_with(
         http_method='DELETE',
-        url=f'{ELEMENTAL_ADDRESS}/live_events/{event_id}', headers=HEADERS, timeout=None)
+        url=f'{ELEMENTAL_ADDRESS}/live_events/{event_id}',
+        headers={'Accept': 'application/xml', 'Content-Type': 'application/xml'}, timeout=None)
 
 
 def test_cancel_event_should_call_send_request_as_expected():
     client = ElementalLive(ELEMENTAL_ADDRESS, USER, API_KEY)
 
     client.generate_headers = mock.Mock()
-    client.generate_headers.return_value = HEADERS
+    client.generate_headers.return_value = {'Accept': 'application/xml', 'Content-Type': 'application/xml'}
 
     client.send_request = mock.Mock()
     client.send_request.return_value = mock_response(status=200)
@@ -212,14 +217,15 @@ def test_cancel_event_should_call_send_request_as_expected():
     client.cancel_event(event_id)
     client.send_request.assert_called_once_with(
         http_method='POST',
-        url=f'{ELEMENTAL_ADDRESS}/live_events/{event_id}/cancel', headers=HEADERS, timeout=None)
+        url=f'{ELEMENTAL_ADDRESS}/live_events/{event_id}/cancel',
+        headers={'Accept': 'application/xml', 'Content-Type': 'application/xml'}, timeout=None)
 
 
 def test_start_event_should_call_send_request_as_expect():
     client = ElementalLive(ELEMENTAL_ADDRESS, USER, API_KEY)
 
     client.generate_headers = mock.Mock()
-    client.generate_headers.return_value = HEADERS
+    client.generate_headers.return_value = {'Accept': 'application/xml', 'Content-Type': 'application/xml'}
 
     client.send_request = mock.Mock()
 
@@ -230,14 +236,14 @@ def test_start_event_should_call_send_request_as_expect():
     client.send_request.assert_called_once_with(
         http_method='POST',
         url=f'{ELEMENTAL_ADDRESS}/live_events/{event_id}/start',
-        headers=HEADERS, body="<start></start>", timeout=None)
+        headers={'Accept': 'application/xml', 'Content-Type': 'application/xml'}, body="<start></start>", timeout=None)
 
 
 def test_reset_event_should_call_send_request_as_expect():
     client = ElementalLive(ELEMENTAL_ADDRESS, USER, API_KEY)
 
     client.generate_headers = mock.Mock()
-    client.generate_headers.return_value = HEADERS
+    client.generate_headers.return_value = {'Accept': 'application/xml', 'Content-Type': 'application/xml'}
 
     client.send_request = mock.Mock()
 
@@ -248,14 +254,14 @@ def test_reset_event_should_call_send_request_as_expect():
     client.send_request.assert_called_once_with(
         http_method='POST',
         url=f'{ELEMENTAL_ADDRESS}/live_events/{event_id}/reset',
-        headers=HEADERS, body='', timeout=None)
+        headers={'Accept': 'application/xml', 'Content-Type': 'application/xml'}, body='', timeout=None)
 
 
 def test_stop_event_should_call_send_request_as_expect():
     client = ElementalLive(ELEMENTAL_ADDRESS, USER, API_KEY)
 
     client.generate_headers = mock.Mock()
-    client.generate_headers.return_value = HEADERS
+    client.generate_headers.return_value = {'Accept': 'application/xml', 'Content-Type': 'application/xml'}
 
     client.send_request = mock.Mock()
     client.send_request.return_value = mock_response(status=200)
@@ -265,7 +271,7 @@ def test_stop_event_should_call_send_request_as_expect():
     client.send_request.assert_called_once_with(
         http_method='POST',
         url=f'{ELEMENTAL_ADDRESS}/live_events/{event_id}/stop',
-        headers=HEADERS, body="<stop></stop>", timeout=None)
+        headers={'Accept': 'application/xml', 'Content-Type': 'application/xml'}, body="<stop></stop>", timeout=None)
 
 
 def send_request_side_effect(**kwargs):
@@ -281,7 +287,7 @@ def test_find_devices_in_use_will_call_send_request_as_expect():
     client = ElementalLive(ELEMENTAL_ADDRESS, USER, API_KEY)
 
     client.generate_headers = mock.Mock()
-    client.generate_headers.return_value = HEADERS
+    client.generate_headers.return_value = {'Accept': 'application/xml', 'Content-Type': 'application/xml'}
 
     client.send_request = mock.Mock()
     client.send_request.return_value = \
@@ -293,14 +299,15 @@ def test_find_devices_in_use_will_call_send_request_as_expect():
     client.send_request.assert_called_with(http_method="GET",
                                            url=f'{ELEMENTAL_ADDRESS}'
                                            f'/live_events?'
-                                           f'filter=active', headers=HEADERS, timeout=None)
+                                           f'filter=active',
+                                           headers={'Accept': 'application/xml', 'Content-Type': 'application/xml'}, timeout=None)
 
 
 def test_find_devices_in_use_will_return_in_used_devices():
     client = ElementalLive(ELEMENTAL_ADDRESS, USER, API_KEY)
 
     client.generate_headers = mock.Mock()
-    client.generate_headers.return_value = HEADERS
+    client.generate_headers.return_value = {'Accept': 'application/xml', 'Content-Type': 'application/xml'}
 
     client.send_request = mock.Mock()
     client.send_request.return_value = \
@@ -315,7 +322,7 @@ def test_get_input_devices_will_call_send_request_as_expect():
     client = ElementalLive(ELEMENTAL_ADDRESS, USER, API_KEY)
 
     client.generate_headers = mock.Mock()
-    client.generate_headers.return_value = HEADERS
+    client.generate_headers.return_value = {'Accept': 'application/xml', 'Content-Type': 'application/xml'}
 
     client.send_request = mock.Mock()
     client.find_devices_in_use = mock.Mock()
@@ -328,14 +335,15 @@ def test_get_input_devices_will_call_send_request_as_expect():
 
     client.send_request.\
         assert_called_with(http_method="GET",
-                           url=f'{ELEMENTAL_ADDRESS}/devices', headers=HEADERS, timeout=None)
+                           url=f'{ELEMENTAL_ADDRESS}/devices',
+                           headers={'Accept': 'application/xml', 'Content-Type': 'application/xml'}, timeout=None)
 
 
 def test_get_input_devices_will_get_right_devices_info():
     client = ElementalLive(ELEMENTAL_ADDRESS, USER, API_KEY)
 
     client.generate_headers = mock.Mock()
-    client.generate_headers.return_value = HEADERS
+    client.generate_headers.return_value = {'Accept': 'application/xml', 'Content-Type': 'application/xml'}
 
     client.send_request = mock.Mock()
     client.find_devices_in_use = mock.Mock()
@@ -363,7 +371,7 @@ def test_get_input_device_by_id_will_call_send_request_as_expect():
     client = ElementalLive(ELEMENTAL_ADDRESS, USER, API_KEY)
 
     client.generate_headers = mock.Mock()
-    client.generate_headers.return_value = HEADERS
+    client.generate_headers.return_value = {'Accept': 'application/xml', 'Content-Type': 'application/xml'}
 
     client.send_request = mock.Mock()
     client.find_devices_in_use = mock.Mock()
@@ -377,14 +385,14 @@ def test_get_input_device_by_id_will_call_send_request_as_expect():
     client.send_request.\
         assert_called_with(http_method="GET",
                            url=f'{ELEMENTAL_ADDRESS}/devices/2',
-                           headers=HEADERS, timeout=None)
+                           headers={'Accept': 'application/xml', 'Content-Type': 'application/xml'}, timeout=None)
 
 
 def test_get_input_device_by_id_will_get_right_devices_info():
     client = ElementalLive(ELEMENTAL_ADDRESS, USER, API_KEY)
 
     client.generate_headers = mock.Mock()
-    client.generate_headers.return_value = HEADERS
+    client.generate_headers.return_value = {'Accept': 'application/xml', 'Content-Type': 'application/xml'}
 
     client.send_request = mock.Mock()
     client.find_devices_in_use = mock.Mock()
@@ -406,7 +414,7 @@ def test_get_preview_will_parse_response_json_as_expect():
     client = ElementalLive(ELEMENTAL_ADDRESS, USER, API_KEY)
 
     client.generate_headers = mock.Mock()
-    client.generate_headers.return_value = HEADERS
+    client.generate_headers.return_value = {'Accept': 'application/xml', 'Content-Type': 'application/xml'}
 
     client.send_request = mock.Mock()
     client.send_request.return_value = mock_response(
@@ -424,7 +432,7 @@ def test_get_preview_will_raise_ElementalException_if_preview_unavaliable():
     client = ElementalLive(ELEMENTAL_ADDRESS, USER, API_KEY)
 
     client.generate_headers = mock.Mock()
-    client.generate_headers.return_value = HEADERS
+    client.generate_headers.return_value = {'Accept': 'application/xml', 'Content-Type': 'application/xml'}
 
     client.send_request = mock.Mock()
     client.send_request.return_value = mock_response(
@@ -447,7 +455,7 @@ def test_describe_event_will_call_send_request_as_expect():
     client = ElementalLive(ELEMENTAL_ADDRESS, USER, API_KEY)
 
     client.generate_headers = mock.Mock()
-    client.generate_headers.return_value = HEADERS
+    client.generate_headers.return_value = {'Accept': 'application/xml', 'Content-Type': 'application/xml'}
 
     client.send_request = mock.Mock()
     response_from_elemental_api = file_fixture('sample_event.xml')
@@ -459,13 +467,13 @@ def test_describe_event_will_call_send_request_as_expect():
     client.send_request.assert_called_once_with(
         http_method='GET',
         url=f'{ELEMENTAL_ADDRESS}/live_events/{event_id}',
-        headers=HEADERS, timeout=None)
+        headers={'Accept': 'application/xml', 'Content-Type': 'application/xml'}, timeout=None)
 
 
 def test_describe_event_will_return_event_info_as_expect():
     client = ElementalLive(ELEMENTAL_ADDRESS, USER, API_KEY)
     client.generate_headers = mock.Mock()
-    client.generate_headers.return_value = HEADERS
+    client.generate_headers.return_value = {'Accept': 'application/xml', 'Content-Type': 'application/xml'}
     client.send_request = mock.Mock()
     response_from_elemental_api = file_fixture('sample_event.xml')
     client.send_request.return_value = mock_response(
@@ -486,7 +494,7 @@ def test_get_event_status():
     client = ElementalLive(ELEMENTAL_ADDRESS, USER, API_KEY)
 
     client.generate_headers = mock.Mock()
-    client.generate_headers.return_value = HEADERS
+    client.generate_headers.return_value = {'Accept': 'application/xml', 'Content-Type': 'application/xml'}
 
     client.send_request = mock.Mock()
     response_from_elemental_api = """<?xml version="1.0" encoding="UTF-8"?>
@@ -516,14 +524,14 @@ def test_get_event_status():
     client.send_request.assert_called_once_with(
         http_method='GET',
         url=f'{ELEMENTAL_ADDRESS}/live_events/{event_id}/status',
-        headers=HEADERS, timeout=None)
+        headers={'Accept': 'application/xml', 'Content-Type': 'application/xml'}, timeout=None)
 
 
 def test_get_event_status_missing_status_in_elemental_response():
     client = ElementalLive(ELEMENTAL_ADDRESS, USER, API_KEY)
 
     client.generate_headers = mock.Mock()
-    client.generate_headers.return_value = HEADERS
+    client.generate_headers.return_value = {'Accept': 'application/xml', 'Content-Type': 'application/xml'}
 
     client.send_request = mock.Mock()
     response_from_elemental_api = """<?xml version="1.0" encoding="UTF-8"?>
@@ -540,7 +548,7 @@ def test_get_event_status_missing_status_in_elemental_response():
     client.send_request.assert_called_once_with(
         http_method='GET',
         url=f'{ELEMENTAL_ADDRESS}/live_events/{event_id}/status',
-        headers=HEADERS, timeout=None)
+        headers={'Accept': 'application/xml', 'Content-Type': 'application/xml'}, timeout=None)
 
 
 @pytest.mark.parametrize('status,expected_result', [
@@ -562,3 +570,53 @@ def test_event_can_delete(status, expected_result):
     }
 
     assert client.event_can_delete('123') is False
+
+
+def test_event_pause_output():
+    client = ElementalLive(ELEMENTAL_ADDRESS, USER, API_KEY)
+    client.generate_headers = mock.Mock()
+    client.generate_headers.return_value = {'Accept': 'application/xml', 'Content-Type': 'application/xml'}
+    client.send_request = mock.Mock()
+    client.send_request.return_value = mock_response(status=200)
+
+    client.event_pause_output(event_id='53', output_id='13')
+
+    client.send_request.assert_called_once_with(
+        http_method='POST',
+        url='FAKE_ADDRESS.com/live_events/53/pause_output',
+        headers={
+            'Accept': 'application/xml',
+            'Content-Type': 'application/xml'
+        },
+        body='<output_id>13</output_id>',
+        timeout=None
+    )
+    send_mock_call = client.send_request.call_args_list[0][1]
+    assert send_mock_call['http_method'] == 'POST'
+    assert send_mock_call['url'] == f'{ELEMENTAL_ADDRESS}/live_events/53/pause_output'
+    assert send_mock_call['headers'] == {'Accept': 'application/xml', 'Content-Type': 'application/xml'}
+
+
+def test_event_unpause_output():
+    client = ElementalLive(ELEMENTAL_ADDRESS, USER, API_KEY)
+    client.generate_headers = mock.Mock()
+    client.generate_headers.return_value = {'Accept': 'application/xml', 'Content-Type': 'application/xml'}
+    client.send_request = mock.Mock()
+    client.send_request.return_value = mock_response(status=200)
+
+    client.event_unpause_output(event_id='53', output_id='13')
+
+    client.send_request.assert_called_once_with(
+        http_method='POST',
+        url='FAKE_ADDRESS.com/live_events/53/unpause_output',
+        headers={
+            'Accept': 'application/xml',
+            'Content-Type': 'application/xml'
+        },
+        body='<output_id>13</output_id>',
+        timeout=None
+    )
+    send_mock_call = client.send_request.call_args_list[0][1]
+    assert send_mock_call['http_method'] == 'POST'
+    assert send_mock_call['url'] == f'{ELEMENTAL_ADDRESS}/live_events/53/unpause_output'
+    assert send_mock_call['headers'] == {'Accept': 'application/xml', 'Content-Type': 'application/xml'}


### PR DESCRIPTION
We need the possibility to pause and unpause specific outputs of events in Elemental Encoders. This PR add the API calls to allow for that.