### PR TITLE
client: check if destinations exists in describe_event 

### DIFF
--- a/elemental/client.py
+++ b/elemental/client.py
@@ -180,7 +180,7 @@ class ElementalLive:
         event_info = {}
 
         destinations = list(ET.fromstring(response.text).iter('destination'))
-        uri = destinations[0].find('uri')
+        uri = destinations[0].find('uri') if destinations else None
         event_info['origin_url'] = uri.text if uri is not None else ''
         if len(destinations) > 1:
             uri = destinations[1].find('uri')

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -443,7 +443,7 @@ def test_get_preview_will_parse_response_json_as_expect():
                        f'images/thumbs/p_1563568669_job_0.jpg'}
 
 
-def test_get_preview_will_raise_ElementalException_if_preview_unavaliable():
+def test_get_preview_will_raise_ElementalException_if_preview_unavailable():
     client = ElementalLive(ELEMENTAL_ADDRESS, USER, API_KEY)
 
     client.generate_headers = mock.Mock()
@@ -503,6 +503,21 @@ def test_describe_event_will_return_event_info_as_expect():
                           'https://vmjhch43nfkghi.data.mediastore.us-east-1.'
                           'amazonaws.com/mortyg3b4/backup/mortyg3b4.m3u8',
                           'status': 'complete'}
+
+
+def test_describe_event_will_return_event_info_with_empty_origin_url_if_destination_is_missing_in_response():
+    client = ElementalLive(ELEMENTAL_ADDRESS, USER, API_KEY)
+    client.generate_headers = mock.Mock()
+    client.generate_headers.return_value = {'Accept': 'application/xml', 'Content-Type': 'application/xml'}
+    client.send_request = mock.Mock()
+    client.send_request.return_value = mock_response(
+        status=200, text='<live_event></live_event>')
+
+    event_id = '139'
+    event_info = client.describe_event(event_id)
+    assert event_info == {'origin_url': '',
+                          'backup_url': None,
+                          'status': 'unknown'}
 
 
 def test_get_event_status():


### PR DESCRIPTION
Check if the response from `send_request` contains `destination`. If not, return `event_info` with an empty origin url.